### PR TITLE
Fix a couple of problems with the expo oauth example.

### DIFF
--- a/authentication-with-expo-and-auth0/README.md
+++ b/authentication-with-expo-and-auth0/README.md
@@ -73,7 +73,8 @@ Now copy over your **domain**, **client id** and **client secret** from the prev
 3. From the expo URL that you see in the address bar on top, copy everything **except for the colon and port** as shown in this screenshot: ![](http://i.imgur.com/8f0qPdg.png)
 4. In `main.js`, set the `redirect_uri` variable by replacing the part `<Expo URL without Port>` with the value you just copied; note that you need to do this in the first part of the `if`-clause, the `else`-part is for the case where the app has been published, then Expo will set the variable for you  
 5. Lastly, back on the config page of the `instagram-example-graphcool` client on the [Auth0 website](https://manage.auth0.com/#/clients) copy the _full value_ of `redirect_uri` from `main.js` into the field **Allowed Callback URLs** (it will look similar to `exp://da-x7f.johndoe.expo-auth0.exp.direct/+/redirect`)
-6. Make sure to click **Save Changes** on the bottom of the page
+6. Make sure that the `JsonWebToken Signature Algorithm` is set to HS256: ![](http://i.imgur.com/h1IW0rN.png)
+7. Make sure to click **Save Changes** on the bottom of the page
 
 
 ### 4. Connect the app with your GraphQL API

--- a/authentication-with-expo-and-auth0/src/PostListView.js
+++ b/authentication-with-expo-and-auth0/src/PostListView.js
@@ -63,7 +63,12 @@ class PostListView extends React.Component {
   componentDidMount() {
 
     // handle redirects after auth0 authentication
-    Linking.addEventListener('url', this._handleAuth0Redirect)
+    Linking.addEventListener('url', this._handleAuth0Redirect);
+    Linking.getInitialURL().then(
+        url => {
+            return this._handleAuth0RedirectUrl(url);
+        }
+    );
 
     // check if a user already exists
     client.query({query: currentUserQuery}).then(
@@ -113,6 +118,7 @@ class PostListView extends React.Component {
           animationType='slide'
           transparent={true}
           visible={this.state.modalVisible}
+          onRequestClose={() => {}}
         >
           <CreatePostView
             userId={this.state.user && this.state.user.id}
@@ -176,11 +182,18 @@ class PostListView extends React.Component {
   }
 
   _handleAuth0Redirect = async (event) => {
-    if (!event.url.includes('+/redirect')) {
-      return
+      if (!event.url.includes('+/redirect')) {
+          return;
+      }
+      Exponent.WebBrowser.dismissBrowser();
+      this._handleAuth0RedirectUrl(event.url)
+  }
+
+  _handleAuth0RedirectUrl = async (url) => {
+    if (!url.includes('+/redirect')) {
+      return;
     }
-    Exponent.WebBrowser.dismissBrowser()
-    const [, queryString] = event.url.split('#')
+    const [, queryString] = url.split('#')
     const responseObj = queryString.split('&').reduce((map, pair) => {
       const [key, value] = pair.split('=')
       map[key] = value // eslint-disable-line


### PR DESCRIPTION
  1. The initialUrl must be handled in order to catch when the app is reloaded by expo
  2. The property onRequestClose must be handled on modal
  3. The readme needs to be updated. The default jwt encoding on auth0 needs to be HS256 and it is now defaulting to RS256.