### PR TITLE
Allow HTTP URLs for iOS in quickstart-with-apollo

### DIFF
--- a/quickstart-with-apollo/ios/ReactNativeApolloInstagramExample/Info.plist
+++ b/quickstart-with-apollo/ios/ReactNativeApolloInstagramExample/Info.plist
@@ -41,14 +41,8 @@
 	<key>NSAppTransportSecurity</key>
 	<!--See http://ste.vn/2015/06/10/configuring-app-transport-security-ios-9-osx-10-11/ -->
 	<dict>
-		<key>NSExceptionDomains</key>
-		<dict>
-			<key>localhost</key>
-			<dict>
-				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
-		</dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
iOS restricts fetching from HTTP urls by default, and quickstart-with-apollo on-boarding is using http://bit.ly (e.g. http://bit.ly/2pLDBrf). The following error is thrown:

<img width="373" alt="screen shot 2017-08-08 at 11 39 59" src="https://user-images.githubusercontent.com/2565771/29066859-db6557d6-7c30-11e7-9565-c6650d8d3d71.png">

The PR allows using HTTP for all domains, which is considered a security risk, but I don't think it's an issue in the example app. Alternatively, I could have whitelisted bit.ly only, but then a user needs to be aware that only HTTPS urls could be added when creating a post - unnecessary mental load.